### PR TITLE
ci (travis | circle-ci): configuration (#63)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - checkout
       - run: mvn clean install
+      - run: bash <(curl -s https://codecov.io/bash)
 
   unit-tests:
     <<: *defaults

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 jdk:
 - oraclejdk8
-after_success:
-- bash <(curl -s https://codecov.io/bash)
+#after_success:
+#- bash <(curl -s https://codecov.io/bash)
 before_script:
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
* ci : integration with codecov.io

* ci (codecov) : removes codecov integration from travis

The codecov integration has been moved from the travis to circle-ci